### PR TITLE
Deployment logging cleanup & documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -260,6 +260,14 @@ hack/htn cloud deploy
 
 This should walk you through the process automatically, and will ask you interactively for the secrets above.
 
+During the first run, things might take a while, as APIs need to be enabled, and resources are created the first time.
+Also, you might need to rerun it, we've seen this kind of failure on new project creation:
+
+```
+│ Error: Error creating service account: googleapi: Error 403: Identity and Access Management (IAM) API has not been used in project [PROJECT-NUMBER] before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/iam.googleapis.com/overview?project=[PROJECT-NUMBER] then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
+│ Details:
+```
+
 ## Github Actions secrets for your personal integration testing environment
 
 After your setup and deployed your project successfully ensure that the integration tests are passing: 

--- a/app/planqtn_cli/src/commands/cloud.ts
+++ b/app/planqtn_cli/src/commands/cloud.ts
@@ -262,7 +262,7 @@ async function setupGCP(
   });
 
   await terraform(
-    `init -backend-config="bucket=${terraformStateBucket}" -backend-config="prefix=${terraformStatePrefix}"`,
+    `init -reconfigure -backend-config="bucket=${terraformStateBucket}" -backend-config="prefix=${terraformStatePrefix}"`,
     true
   );
 
@@ -824,7 +824,16 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 
 gcloud projects add-iam-policy-binding $PROJECT_ID \
  --member="serviceAccount:tf-deployer@$PROJECT_ID.iam.gserviceaccount.com"  \
- --role="roles/secretmanager.secretAccessor"
+ --role="roles/secretmanager.secretAccessor
+ 
+ gcloud projects add-iam-policy-binding $PROJECT_ID \
+ --member="serviceAccount:tf-deployer@$PROJECT_ID.iam.gserviceaccount.com"  \
+ --role="roles/resourcemanager.projectIamAdmin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+ --member="serviceAccount:tf-deployer@$PROJECT_ID.iam.gserviceaccount.com"  \
+ --role="roles/logging.configWriter"
+ 
 
 3. Download a key for the service account:
 
@@ -881,7 +890,6 @@ cat ~/.planqtn/.config/tf-deployer-svc.json | base64 -w 0`,
   }
 
   async loadGcpOutputs(): Promise<void> {
-    console.log("Loading GCP outputs...");
     try {
       // Get Terraform outputs
       const apiUrl = await terraform(`output -raw api_service_url`);
@@ -900,8 +908,6 @@ cat ~/.planqtn/.config/tf-deployer-svc.json | base64 -w 0`,
       if (gcpSvcAccountKeyVar) {
         gcpSvcAccountKeyVar.setValue(rawServiceAccountKey!);
       }
-
-      console.log("Terraform outputs loaded successfully.");
     } catch {
       // Ignore error
     }


### PR DESCRIPTION
During the CI env creation I realized that more roles were needed for the tf-deployer service account. I added those into the hints description of the tool. 