### PR TITLE
cutting off ~700MB from the job and api images

### DIFF
--- a/app/planqtn_api/Dockerfile
+++ b/app/planqtn_api/Dockerfile
@@ -1,22 +1,45 @@
-FROM python:3.12-slim
+# Multi-stage build for optimized image size
+# Build stage
+FROM python:3.12-slim AS builder
 
 WORKDIR /app
 
+# Install uv for faster dependency management
 RUN pip install --upgrade pip uv
 
+# Copy dependency files
 COPY pyproject.toml /app/pyproject.toml
-COPY app/planqtn_api/requirements.txt /app/planqtn_api/requirements.txt   
+COPY app/planqtn_api/requirements.txt /app/planqtn_api/requirements.txt
 
+# Install dependencies to a virtual environment
 RUN uv pip install -r pyproject.toml -r /app/planqtn_api/requirements.txt --system
 
+# Copy source code
 COPY ./qlego /app/qlego
 COPY ./app/planqtn_api /app/planqtn_api
 COPY ./app/planqtn_types /app/planqtn_types
 
+# Runtime stage using distroless Python
+FROM gcr.io/distroless/python3-debian12:latest
 
+# Copy Python from builder stage
+COPY --from=builder /usr/local/bin/python /usr/local/bin/python
+COPY --from=builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=builder /usr/local/lib/libpython3.12.so* /usr/local/lib/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libpython3.12.so* /usr/lib/x86_64-linux-gnu/
+
+# Copy installed packages and site-packages
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+
+# Copy application code
+COPY --from=builder /app/qlego /app/qlego
+COPY --from=builder /app/planqtn_api /app/planqtn_api
+COPY --from=builder /app/planqtn_types /app/planqtn_types
+
+# Set working directory and environment
 WORKDIR /app
-
-ENV TERM=xterm
 ENV PYTHONPATH=/app
+ENV TERM=xterm
 
-ENTRYPOINT ["python", "/app/planqtn_api/planqtn_server.py"]
+# Use distroless entrypoint
+ENTRYPOINT ["/usr/local/bin/python", "/app/planqtn_api/planqtn_server.py"]

--- a/app/planqtn_jobs/Dockerfile
+++ b/app/planqtn_jobs/Dockerfile
@@ -1,23 +1,46 @@
-FROM python:3.12-slim
+# Multi-stage build for optimized image size
+# Build stage
+FROM python:3.12-slim AS builder
 
 WORKDIR /app
 
+# Install uv for faster dependency management
 RUN pip install --upgrade pip uv
 
+# Copy dependency files
 COPY pyproject.toml /app/pyproject.toml
 COPY app/planqtn_jobs/requirements.txt /app/planqtn_jobs/requirements.txt
 
+# Install dependencies to a virtual environment
 RUN uv pip install -r pyproject.toml -r /app/planqtn_jobs/requirements.txt --system
 
+# Copy source code
 COPY ./qlego /app/qlego
 COPY ./app/planqtn_types /app/planqtn_types
 COPY ./app/planqtn_jobs /app/planqtn_jobs
 
+# Runtime stage using distroless Python
+FROM gcr.io/distroless/python3-debian12:latest
 
+# Copy Python from builder stage
+COPY --from=builder /usr/local/bin/python /usr/local/bin/python
+COPY --from=builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=builder /usr/local/lib/libpython3.12.so* /usr/local/lib/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libpython3.12.so* /usr/lib/x86_64-linux-gnu/
+
+# Copy installed packages and site-packages
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+
+# Copy application code
+COPY --from=builder /app/qlego /app/qlego
+COPY --from=builder /app/planqtn_types /app/planqtn_types
+COPY --from=builder /app/planqtn_jobs /app/planqtn_jobs
+
+# Set working directory and environment
 WORKDIR /app
-
-ENV TERM=xterm
 ENV PYTHONPATH=/app
+ENV TERM=xterm
 
-ENTRYPOINT ["python"]
+# Use distroless entrypoint
+ENTRYPOINT ["/usr/local/bin/python"]
 


### PR DESCRIPTION
Having smaller images helps with a smaller kernel as well as a faster Cloud Run spin up time. 
Using distroless images, the api image went down from 1.6GB to 913MB and the jobs image to 937MB from 1.66GB.