### PR TITLE
infra: gate SA key output + drop run.admin from Cloud Run SA

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -387,6 +387,11 @@ Use terraform to get the Cloud Run service account key:
 
 ```
 cd app/gcp
+# Recommended: retrieve from Secret Manager (production-safe)
+# gcloud secrets versions access latest --secret=api_service_account_key --format='get(payload.data)' | tr '_-' '/+' | base64 --decode
+
+# Ephemeral/dev only: expose via Terraform output by passing an explicit flag
+# (not recommended for production)
 $HOME/.planqtn/bin/terraform output -raw api_service_account_key | base64 --decode
 ```
 

--- a/app/gcp/iam.tf
+++ b/app/gcp/iam.tf
@@ -9,7 +9,6 @@ resource "google_service_account" "cloud_run_svc" {
 resource "google_project_iam_member" "cloud_run_svc_roles" {
   for_each = toset([
     "roles/secretmanager.secretAccessor",
-    "roles/run.admin",           # To manage Cloud Run services
     "roles/run.invoker",         # To invoke Cloud Run services
     "roles/run.jobsExecutor",    # To execute Cloud Run jobs
     "roles/logging.logWriter",   # To write logs

--- a/app/gcp/outputs.tf
+++ b/app/gcp/outputs.tf
@@ -3,11 +3,6 @@ output "api_service_url" {
   value       = google_cloud_run_v2_service.planqtn_api.uri
 }
 
-output "api_service_account_key" {
-  description = "The service account key for the API service"
-  value       = google_service_account_key.api_svc_key.private_key
-  sensitive   = true
-}
 
 output "ui_service_url" {
   description = "The URL of the deployed UI service"

--- a/app/gcp/outputs.tf
+++ b/app/gcp/outputs.tf
@@ -3,6 +3,15 @@ output "api_service_url" {
   value       = google_cloud_run_v2_service.planqtn_api.uri
 }
 
+# WARNING: This output exposes a private key and should remain disabled by default.
+# Enable only in safe, ephemeral environments by setting
+#   -var="expose_api_service_account_key_output=true"
+# Prefer using Secret Manager for access in production.
+output "api_service_account_key" {
+  description = "The service account key for the API service (use only if explicitly enabled)"
+  value       = var.expose_api_service_account_key_output ? google_service_account_key.api_svc_key.private_key : null
+  sensitive   = true
+}
 
 output "ui_service_url" {
   description = "The URL of the deployed UI service"

--- a/app/gcp/variables.tf
+++ b/app/gcp/variables.tf
@@ -52,4 +52,11 @@ variable "google_credentials" {
   type        = string
   default     = ""
   sensitive   = true
+}
+
+variable "expose_api_service_account_key_output" {
+  description = "If true, exposes the API service account private key via Terraform output (not recommended for prod)."
+  type        = bool
+  default     = false
+  sensitive   = true
 } 

--- a/app/planqtn_cli/src/commands/cloud.ts
+++ b/app/planqtn_cli/src/commands/cloud.ts
@@ -979,9 +979,15 @@ cat ~/.planqtn/.config/tf-deployer-svc.json | base64 -w 0`,
     try {
       // Get Terraform outputs
       const apiUrl = await terraform(`output -raw api_service_url`);
-      const rawServiceAccountKey = await terraform(
-        `output -raw api_service_account_key`
-      );
+      let rawServiceAccountKey: string | undefined;
+      try {
+        rawServiceAccountKey = await terraform(
+          `output -raw api_service_account_key`
+        );
+      } catch (e) {
+        // Output may be disabled by default; instruct how to enable for ephemeral/dev if needed
+        rawServiceAccountKey = undefined;
+      }
       // Set values on the Variable instances
       const apiUrlVar = this.variables.find((v) => v.getName() === "apiUrl");
       const gcpSvcAccountKeyVar = this.variables.find(
@@ -991,7 +997,7 @@ cat ~/.planqtn/.config/tf-deployer-svc.json | base64 -w 0`,
       if (apiUrlVar) {
         apiUrlVar.setValue(apiUrl!);
       }
-      if (gcpSvcAccountKeyVar) {
+      if (gcpSvcAccountKeyVar && rawServiceAccountKey) {
         gcpSvcAccountKeyVar.setValue(rawServiceAccountKey!);
       }
     } catch {


### PR DESCRIPTION
### Why
- Reduce secret exposure risk and enforce least privilege.
### What
- Gate API service account key Terraform output behind a boolean:
  - expose_api_service_account_key_output=false by default.
  - Output only when explicitly enabled for ephemeral/dev.
- Update docs to prefer Secret Manager; CLI tolerates missing output.
- Drop roles/run.admin from the Cloud Run execution service account.

### Ops
- Run terraform apply in the target GCP project.
- Rotate any previously exposed service account key; store only in Secret Manager.

### Files
- app/gcp/variables.tf
- app/gcp/outputs.tf
- DEVELOPMENT.md
- app/planqtn_cli/src/commands/cloud.ts