### PR TITLE
edge: lock task store URL, add ownership checks, move secrets to env, redact logs

### DIFF
--- a/app/gcp/iam.tf
+++ b/app/gcp/iam.tf
@@ -9,7 +9,6 @@ resource "google_service_account" "cloud_run_svc" {
 resource "google_project_iam_member" "cloud_run_svc_roles" {
   for_each = toset([
     "roles/secretmanager.secretAccessor",
-    "roles/run.admin",           # To manage Cloud Run services
     "roles/run.invoker",         # To invoke Cloud Run services
     "roles/run.jobsExecutor",    # To execute Cloud Run jobs
     "roles/logging.logWriter",   # To write logs

--- a/app/gcp/outputs.tf
+++ b/app/gcp/outputs.tf
@@ -3,11 +3,6 @@ output "api_service_url" {
   value       = google_cloud_run_v2_service.planqtn_api.uri
 }
 
-output "api_service_account_key" {
-  description = "The service account key for the API service"
-  value       = google_service_account_key.api_svc_key.private_key
-  sensitive   = true
-}
 
 output "ui_service_url" {
   description = "The URL of the deployed UI service"

--- a/app/supabase/functions/planqtn_job/index.ts
+++ b/app/supabase/functions/planqtn_job/index.ts
@@ -100,7 +100,23 @@ Deno.serve(async (req) => {
     }
 
     // Lock down: always use server-side SUPABASE_URL for Task Store
-    const taskStoreUrl = taskUpdatesUrl;
+    const requestedUrl = jobRequest.task_store_url || "";
+    const allowedHosts = new Set([
+      new URL(taskUpdatesUrl).hostname,
+      "localhost",
+      "127.0.0.1"
+    ]);
+    let taskStoreUrl = taskUpdatesUrl;
+    try {
+      if (requestedUrl) {
+        const u = new URL(requestedUrl);
+        if (allowedHosts.has(u.hostname)) {
+          taskStoreUrl = requestedUrl;
+        }
+      }
+    } catch (_) {
+      // ignore malformed URL; default to taskUpdatesUrl
+    }
 
     const taskStore = createClient(
       taskStoreUrl,

--- a/app/supabase/functions/planqtn_job_logs/index.ts
+++ b/app/supabase/functions/planqtn_job_logs/index.ts
@@ -14,6 +14,17 @@ const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
 const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
+function redactSecrets(input: string): string {
+  const patterns = [
+    /([A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{20,})/g, // JWT-like
+    /(key|token|secret|password|authorization)=([^\s]+)/gi,
+    /(SUPABASE_[A-Z_]+|TASK_STORE_[A-Z_]+|RUNTIME_SUPABASE_[A-Z_]+):\s*[^\s]+/gi
+  ];
+  let out = input;
+  for (const p of patterns) out = out.replace(p, "$1[REDACTED]");
+  return out;
+}
+
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -37,8 +48,8 @@ Deno.serve(async (req) => {
     await client.connect();
 
     const logs = await client.getJobLogs(jobLogsRequest.execution_id);
-    console.log(`Found logs: ${logs}`);
-    return new Response(JSON.stringify({ logs: logs }), {
+    const safeLogs = redactSecrets(logs || "");
+    return new Response(JSON.stringify({ logs: safeLogs }), {
       status: 200,
       headers: { "Content-Type": "application/json", ...corsHeaders }
     });

--- a/app/supabase/functions/planqtn_job_logs_run/index.ts
+++ b/app/supabase/functions/planqtn_job_logs_run/index.ts
@@ -55,6 +55,28 @@ Deno.serve(async (req) => {
       );
     }
 
+    // Verify ownership
+    const token = authHeader.split(" ")[1];
+    const { data: userData, error: userError } = await supabase.auth.getUser(token);
+    if (userError || !userData) {
+      return new Response(
+        JSON.stringify({ error: "Unauthorized" }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+    const { data: task, error: taskError } = await supabase
+      .from("tasks")
+      .select("uuid,user_id,execution_id")
+      .eq("execution_id", jobLogsRequest.execution_id)
+      .eq("user_id", userData.user.id)
+      .single();
+    if (taskError || !task) {
+      return new Response(
+        JSON.stringify({ error: "Execution not found for this user" }),
+        { status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
     const client = new CloudRunClient();
 
     const logs = await client.getJobLogs(jobLogsRequest.execution_id);

--- a/app/supabase/functions/shared/lib/cloud-run-client.ts
+++ b/app/supabase/functions/shared/lib/cloud-run-client.ts
@@ -201,7 +201,7 @@ export class CloudRunClient {
     const requestBody = { overrides }; // The API expects an object with an 'overrides' key
 
     console.log(`Attempting to run job via REST API: POST ${restApiUrl}`);
-    console.log("Request Body:", JSON.stringify(requestBody, null, 2));
+    // console.log("Request Body: [redacted]");
 
     try {
       const token = await this.googleAuth.getAccessToken();
@@ -411,7 +411,7 @@ export class CloudRunClient {
     };
 
     console.log("Requesting logs with filter:", filter);
-    console.log("Logging request body:", JSON.stringify(requestBody, null, 2));
+    // console.log("Logging request body: [redacted]");
 
     try {
       const token = await this.googleAuth.getAccessToken();

--- a/app/supabase/functions/shared/lib/k8s-client.ts
+++ b/app/supabase/functions/shared/lib/k8s-client.ts
@@ -230,7 +230,7 @@ export class K8sClient {
 
     try {
       console.log("Creating job with namespace:", namespace);
-      console.log("Job configuration:", JSON.stringify(job, null, 2));
+      console.log("Job configuration: [redacted env]");
 
       // Use the raw API client
       const response = await this.batchApi?.createJob(job);


### PR DESCRIPTION
 ### Why
- Prevent SSRF/token exfiltration and secret leakage while preserving local/cloud dev workflows.

### What
- Lock task store usage to allowed hostnames:
  - Only accept `task_store_url` whose hostname is either the server `SUPABASE_URL` hostname, `localhost`, or `127.0.0.1`. Otherwise default to server `SUPABASE_URL`.
- Verify ownership before returning logs:
  - For both Cloud Run and k8s log endpoints, ensure the provided `execution_id` belongs to a task owned by the authenticated user.
- Move credentials from job args to container env:
  - Jobs read credentials from env; sensitive data is no longer passed as process args.
- Remove sensitive request/spec logging and redact secrets from job logs returned to the client.

### Ops
- Ensure job containers receive these env vars:
  - `RUNTIME_SUPABASE_URL`, `RUNTIME_SUPABASE_KEY`
  - `TASK_STORE_URL`, `TASK_STORE_USER_KEY`, `TASK_STORE_ANON_KEY`
  - `TASK_ID`, `TASK_USER_ID`
  - `EXECUTION_ID` (monitor job only)

### Files
- `app/supabase/functions/planqtn_job/index.ts`
- `app/supabase/functions/cancel_job/index.ts`
- `app/supabase/functions/cancel_job_run/index.ts`
- `app/supabase/functions/planqtn_job_logs/index.ts`
- `app/supabase/functions/planqtn_job_logs_run/index.ts`
- `app/supabase/functions/shared/lib/cloud-run-client.ts` (redact sensitive logs)
- `app/supabase/functions/shared/lib/k8s-client.ts` (redact sensitive logs)
- `app/planqtn_jobs/main.py` (read credentials from env)