### PR TITLE
Fix: update submit button label in TannerDialog

### DIFF
--- a/app/ui/src/features/network-apis/TannerDialog.tsx
+++ b/app/ui/src/features/network-apis/TannerDialog.tsx
@@ -370,7 +370,7 @@ export const TannerDialog: React.FC<TannerDialogProps> = ({
             Cancel (Esc)
           </Button>
           <Button colorScheme="blue" onClick={handleSubmit}>
-            Create Network (Ctrl+Enter)
+            {title === "Custom Lego Dialog" ? "Create Lego (Ctrl+Enter)" : "Create Network (Ctrl+Enter)"}
           </Button>
         </ModalFooter>
       </ModalContent>


### PR DESCRIPTION
Updated the submit button label in TannerDialog to display "Create Lego (Ctrl+Enter)" when used in the Custom Lego Dialog. This improves clarity for users by showing the correct action shortcut. Verified that no other dialogs or components are affected.