### PR TITLE
Fix timing race condition in ProgressReporter.iterate()

### DIFF
--- a/planqtn/progress_reporter.py
+++ b/planqtn/progress_reporter.py
@@ -254,7 +254,7 @@ class ProgressReporter(abc.ABC):
         for item in iterable:
             yield item
             bottom_iterator_state.update()
-            if time.time() - time_last_report > self.iteration_report_frequency:
+            if time.time() - time_last_report >= self.iteration_report_frequency:
                 time_last_report = time.time()
 
                 self.log_result(


### PR DESCRIPTION
Fixes #191

The progress reporter had a race condition where very fast iterations could complete with time.time() returning identical values before and after the iteration body. This caused the condition:

    if time.time() - time_last_report > self.iteration_report_frequency:

to evaluate to False (0.0 > 0.0), preventing intermediate progress reports from being logged.

Changed the condition to use >= instead of >, ensuring reports are always logged when the time delta equals or exceeds the report frequency, including the default value of 0.0.

This resolves the flaky test failure where test_progress_reporter_nested_iterations expected 6 history entries but sometimes only received 5.